### PR TITLE
feat: add platform_and_tools_util, use i tin conflict_handler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='swane',
           "nibabel<=5.3.0",
           "packaging",
           "PySide6_VerticalQTabWidget==0.0.3",
-          "numpy",
+          "numpy==2.2.4",
           "cryptography"
       ],
       python_requires=">=3.7",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='swane',
       ],
       license='MIT',
       install_requires=[
-          "networkx==3.4.2"
+          "networkx==3.4.2",
           "nipype==1.10.0",
           "Pyside6",
           "pydicom==3.0.1",
@@ -34,7 +34,7 @@ setup(name='swane',
           "nibabel<=5.3.0",
           "packaging",
           "PySide6_VerticalQTabWidget==0.0.3",
-          "numpy==2.2.4",
+          "numpy",
           "cryptography"
       ],
       python_requires=">=3.7",

--- a/swane/utils/fsl_conflict_handler.py
+++ b/swane/utils/fsl_conflict_handler.py
@@ -2,7 +2,7 @@ import os
 import sys
 from swane import strings
 import subprocess
-from platform_and_tools_utils import is_command_available, is_linux, is_mac
+from utils.platform_and_tools_utils import is_command_available, is_linux, is_mac
 
 
 FSL_CONFLICT_PATH = "fsl/bin"
@@ -81,7 +81,7 @@ def fsl_conflict_check() -> bool:
         return True
 
     # This function uses fsl built-in qt library to show a warning: ignore IDE import error!
-    from PyQt5.QtWidgets import QApplication, QLabel, QMessageBox
+    from PySide6.QtWidgets import QApplication, QMessageBox
 
     app = QApplication([])
     app.setApplicationDisplayName(strings.APPNAME)

--- a/swane/utils/fsl_conflict_handler.py
+++ b/swane/utils/fsl_conflict_handler.py
@@ -96,8 +96,9 @@ def fsl_conflict_check() -> bool:
     msg_box.setStandardButtons(QMessageBox.Yes | QMessageBox.Retry | QMessageBox.Cancel)
     msg_box.button(QMessageBox.Yes).setText(strings.fsl_python_error_fix)
     msg_box.button(QMessageBox.Retry).setText(strings.fsl_python_error_restart)
-    msg_box.button(QMessageBox.Cancel).setText(strings.fsl_python_error_exit)
+    
     if is_command_available('xclip') or is_mac():
+        msg_box.button(QMessageBox.Cancel).setText(strings.fsl_python_error_exit)
         msg_box.setDefaultButton(QMessageBox.Cancel)
     ret = msg_box.exec()
 
@@ -106,7 +107,7 @@ def fsl_conflict_check() -> bool:
     elif ret == QMessageBox.Yes:
         config_file_fix(config_file)
         runtime_fix()
-    elif ret == QMessageBox.Cancel:
+    elif ret == QMessageBox.Cancel and (is_command_available('xclip') or is_mac()):
         copy_fix_to_clipboard()
 
     return False

--- a/swane/utils/fsl_conflict_handler.py
+++ b/swane/utils/fsl_conflict_handler.py
@@ -81,7 +81,7 @@ def fsl_conflict_check() -> bool:
         return True
 
     # This function uses fsl built-in qt library to show a warning: ignore IDE import error!
-    from PySide6.QtWidgets import QApplication, QMessageBox
+    from PyQt5.QtWidgets import QApplication, QMessageBox
 
     app = QApplication([])
     app.setApplicationDisplayName(strings.APPNAME)

--- a/swane/utils/fsl_conflict_handler.py
+++ b/swane/utils/fsl_conflict_handler.py
@@ -2,7 +2,7 @@ import os
 import sys
 from swane import strings
 import subprocess
-from utils.platform_and_tools_utils import is_command_available, is_linux, is_mac
+from swane.utils.platform_and_tools_utils import is_command_available, is_linux, is_mac
 
 
 FSL_CONFLICT_PATH = "fsl/bin"

--- a/swane/utils/fsl_conflict_handler.py
+++ b/swane/utils/fsl_conflict_handler.py
@@ -2,6 +2,8 @@ import os
 import sys
 from swane import strings
 import subprocess
+from platform_and_tools_utils import is_command_available, is_linux, is_mac
+
 
 FSL_CONFLICT_PATH = "fsl/bin"
 FREESURFER_CONFIG_FILE = "SetUpFreeSurfer.sh"
@@ -57,9 +59,11 @@ def config_file_fix(config_file: str):
 
 def copy_fix_to_clipboard():
     # Linux shell copy command
-    subprocess.run("xclip -selection c", shell=True, text=True, input=FIX_LINE)
+    if is_linux():
+        subprocess.run("xclip -selection c", shell=True, text=True, input=FIX_LINE)
     # MacOS shell copy command
-    subprocess.run("pbcopy", shell=True, text=True, input=FIX_LINE)
+    if is_mac():
+        subprocess.run("pbcopy", shell=True, text=True, input=FIX_LINE)
 
 
 def fsl_conflict_check() -> bool:
@@ -93,7 +97,8 @@ def fsl_conflict_check() -> bool:
     msg_box.button(QMessageBox.Yes).setText(strings.fsl_python_error_fix)
     msg_box.button(QMessageBox.Retry).setText(strings.fsl_python_error_restart)
     msg_box.button(QMessageBox.Cancel).setText(strings.fsl_python_error_exit)
-    msg_box.setDefaultButton(QMessageBox.Cancel)
+    if is_command_available('xclip') or is_mac():
+        msg_box.setDefaultButton(QMessageBox.Cancel)
     ret = msg_box.exec()
 
     if ret == QMessageBox.Retry:

--- a/swane/utils/platform_and_tools_utils.py
+++ b/swane/utils/platform_and_tools_utils.py
@@ -1,0 +1,37 @@
+import shutil
+import platform
+
+def is_command_available(command: str) -> bool:
+    """
+    Check if a command exists in the system PATH.
+
+    :param command: Name of the command to check
+    :return: True if the command exists, False otherwise
+    """
+    return shutil.which(command) is not None
+
+def get_os_type() -> str:
+    """
+    Get the operating system type.
+
+    :return: 'mac' if macOS, 'linux' if Linux, 'other' otherwise
+    """
+    system = platform.system().lower()
+    if system == "darwin":
+        return "mac"
+    elif system == "linux":
+        return "linux"
+    else:
+        return "other"
+
+def is_mac() -> bool:
+    """
+    Check if the operating system is macOS.
+    """
+    return get_os_type() == "mac"
+
+def is_linux() -> bool:
+    """
+    Check if the operating system is Linux.
+    """
+    return get_os_type() == "linux"


### PR DESCRIPTION
with this pr, we aim to add some check for the "fix and restart" process
- Let's be sure that the command executed are done only if we are in right system (linux or Mac)
- Let's check if `x-clip` is installed

If one of this condition is false we avoid to show the button!